### PR TITLE
Add qrc file for missing images that are on the various screens

### DIFF
--- a/User Interface/RetrieverEssentials.qrc
+++ b/User Interface/RetrieverEssentials.qrc
@@ -1,0 +1,8 @@
+<RCC>
+  <qresource prefix="my_resources">
+    <file>Logos/UMBCretrievers_LOGO.jpg</file>
+    <file>Logos/CheckoutCart1.jpg</file>
+    <file>Logos/CheckoutCart2.png</file>
+    <file>Logos/Retriever Essential.png</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
Forgot to add qrc file, which holds all the imported images displayed on multiple screens. You need to download it and put it in the same folder as the other files to view them properly.